### PR TITLE
Add City property to Car model and update migrations

### DIFF
--- a/Autominus.Server/Migrations/20250422063714_Int.Designer.cs
+++ b/Autominus.Server/Migrations/20250422063714_Int.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Autominus.Server.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Autominus.Server.Migrations
 {
     [DbContext(typeof(ModelsContext))]
-    partial class ModelsContextModelSnapshot : ModelSnapshot
+    [Migration("20250422063714_Int")]
+    partial class Int
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Autominus.Server/Migrations/20250422063714_Int.cs
+++ b/Autominus.Server/Migrations/20250422063714_Int.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Autominus.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class Int : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "City",
+                table: "Cars",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "City",
+                table: "Cars");
+        }
+    }
+}

--- a/Autominus.Server/Models/Car.cs
+++ b/Autominus.Server/Models/Car.cs
@@ -27,6 +27,7 @@
         public List<string>? ImageUrls { get; set; }
         public string? Location { get; set; }
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public string? City { get; set; }
 
         // Navigacijos savybė: automobilis priklauso vartotojui
         public User User { get; set; }


### PR DESCRIPTION
This commit introduces a new `City` property to the `Car` model, enabling the storage of the city associated with each car. The change is reflected in the following files:
- Added `City` property in `ModelsContextModelSnapshot.cs`.
- Updated `Car.cs` to include the new `City` property.
- Created migration class `20250422063714_Int` to add and remove the `City` column in the `Cars` table.
- Updated `20250422063714_Int.Designer.cs` to ensure the database schema aligns with the updated model.